### PR TITLE
Prevents updating qmore configuration on every job reservation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,12 @@ Alternatively, if you have some other way of launching workers (e.g. qless-pool)
 
     Qless::Pool.pool_factory.reserver_class = Qmore::JobReserver
     Qmore.client == Qless::Pool.pool_factory.client
-    # Redis persistence defaults to using the Qmore.client.redis,
-    # however a completely separate redis connection may be used.
+
+    # Enabling Monitoring
+    # Redis persistence defaults to using the same connection
+    # used for reserving jobs, however it is not required that they
+    # be the same redis connection. I.e. you can store configuration
+    # on a completely separate instance of redis.
     Qmore.persistence = Qless::Persistence::Redis.new(Qmore.client.redis)
     # Configure the monitor thread with the persistence type, and the interval at which to update
     # Monitor defaults to using Qmore.persistence and 2 minutes

--- a/README.md
+++ b/README.md
@@ -14,11 +14,12 @@ Alternatively, if you have some other way of launching workers (e.g. qless-pool)
 
     Qless::Pool.pool_factory.reserver_class = Qmore::JobReserver
     Qmore.client == Qless::Pool.pool_factory.client
-    # Redis persistance defaults to using the Qmore.client.
-    Qmore.persistance = Qless::Persistance::Redis.new(Qmore.client.redis)
-    # Configure the monitor thread with the persistance type, and the interval at which to update
-    # Monitor defaults to using Qmore.persistance and 2 minutes
-    Qmore.monitor = Qless::persistance::Monitor.new(Qmore.persistance, 120)
+    # Redis persistence defaults to using the Qmore.client.redis,
+    # however a completely separate redis connection may be used.
+    Qmore.persistence = Qless::Persistence::Redis.new(Qmore.client.redis)
+    # Configure the monitor thread with the persistence type, and the interval at which to update
+    # Monitor defaults to using Qmore.persistence and 2 minutes
+    Qmore.monitor = Qless::persistence::Monitor.new(Qmore.persistence, 120)
     # Start up monitor thread
     Qmore.monitor.start
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Alternatively, if you have some other way of launching workers (e.g. qless-pool)
     # Configure the monitor thread with the persistence type, and the interval at which to update
     # Monitor defaults to using Qmore.persistence and 2 minutes
     Qmore.monitor = Qless::persistence::Monitor.new(Qmore.persistence, 120)
-    # Start up monitor thread
+    # Start up monitor thread.
     Qmore.monitor.start
 
 To enable the web UI, use a config.ru similar to the following depending on your environment:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Alternatively, if you have some other way of launching workers (e.g. qless-pool)
     # Configure the monitor thread with the persistence type, and the interval at which to update
     # Monitor defaults to using Qmore.persistence and 2 minutes
     Qmore.monitor = Qless::persistence::Monitor.new(Qmore.persistence, 120)
-    # Start up monitor thread.
+    # Start up monitor thread
     Qmore.monitor.start
 
 To enable the web UI, use a config.ru similar to the following depending on your environment:

--- a/README.md
+++ b/README.md
@@ -14,12 +14,19 @@ Alternatively, if you have some other way of launching workers (e.g. qless-pool)
 
     Qless::Pool.pool_factory.reserver_class = Qmore::JobReserver
     Qmore.client == Qless::Pool.pool_factory.client
+    # Redis persistance defaults to using the Qmore.client.
+    Qmore.persistance = Qless::Persistance::Redis.new(Qmore.client.redis)
+    # Configure the monitor thread with the persistance type, and the interval at which to update
+    # Monitor defaults to using Qmore.persistance and 2 minutes
+    Qmore.monitor = Qless::persistance::Monitor.new(Qmore.persistance, 120)
+    # Start up monitor thread
+    Qmore.monitor.start
 
 To enable the web UI, use a config.ru similar to the following depending on your environment:
 
     require 'qless/server'
     require 'qmore-server'
-    
+
     Qless::Server.client = Qless::Client.new(:host => "some-host", :port => 7000)
     Qmore.client = Qless::Server.client
     run Qless::Server.new(Qmore.client)
@@ -94,18 +101,18 @@ And I run my worker with QUEUES=\*
 
 If I set my patterns like:
 
-high\_\* (fairly unchecked)  
-default (fairly unchecked)  
-low\_\* (fairly unchecked)  
+high\_\* (fairly unchecked)
+default (fairly unchecked)
+low\_\* (fairly unchecked)
 
 Then, the worker will scan the queues for work in this order:
 high_bar, high_baz, high_foo, myqueue, otherqueue, somequeue, low_bar, low_baz, low_foo
 
 If I set my patterns like:
 
-high\_\* (fairly checked)  
-default (fairly checked)  
-low\_\* (fairly checked)  
+high\_\* (fairly checked)
+default (fairly checked)
+low\_\* (fairly checked)
 
 Then, the worker will scan the queues for work in this order:
 

--- a/lib/qmore.rb
+++ b/lib/qmore.rb
@@ -1,5 +1,6 @@
 require 'qless'
 require 'qless/worker'
+require 'gem_logger'
 require 'qmore/configuration'
 require 'qmore/persistence'
 require 'qmore/attributes'

--- a/lib/qmore.rb
+++ b/lib/qmore.rb
@@ -1,7 +1,7 @@
 require 'qless'
 require 'qless/worker'
 require 'qmore/configuration'
-require 'qmore/persistance'
+require 'qmore/persistence'
 require 'qmore/attributes'
 require 'qmore/job_reserver'
 
@@ -16,23 +16,23 @@ module Qmore
   end
 
   def self.configuration
-    @configuration ||= Qmore.persistance.load
+    @configuration ||= Qmore::LegacyConfiguration.new(Qmore.persistence)
   end
 
   def self.configuration=(configuration)
     @configuration = configuration
   end
 
-  def self.persistance
-    @persistance ||= Qmore::Persistance::Redis.new(self.client.redis)
+  def self.persistence
+    @persistence ||= Qmore::Persistence::Redis.new(self.client.redis)
   end
 
-  def self.persistance=(manager)
-    @persistance = manager
+  def self.persistence=(manager)
+    @persistence = manager
   end
 
   def self.monitor
-    @monitor ||= Qmore::Persistance::Monitor.new(self.persistance, 120)
+    @monitor ||= Qmore::Persistence::Monitor.new(self.persistence, 120)
   end
 
   def self.monitor=(monitor)

--- a/lib/qmore.rb
+++ b/lib/qmore.rb
@@ -1,16 +1,42 @@
 require 'qless'
 require 'qless/worker'
+require 'qmore/configuration'
+require 'qmore/persistance'
 require 'qmore/attributes'
 require 'qmore/job_reserver'
 
 module Qmore
-  
+
   def self.client=(client)
     @client = client
   end
-  
+
   def self.client
-    @client ||= Qless::Client.new 
+    @client ||= Qless::Client.new
+  end
+
+  def self.configuration
+    @configuration ||= Qmore.persistance.load
+  end
+
+  def self.configuration=(configuration)
+    @configuration = configuration
+  end
+
+  def self.persistance
+    @persistance ||= Qmore::Persistance::Redis.new(self.client.redis)
+  end
+
+  def self.persistance=(manager)
+    @persistance = manager
+  end
+
+  def self.monitor
+    @monitor ||= Qmore::Persistance::Monitor.new(self.persistance, 120)
+  end
+
+  def self.monitor=(monitor)
+    @monitor = monitor
   end
 end
 

--- a/lib/qmore/configuration.rb
+++ b/lib/qmore/configuration.rb
@@ -1,0 +1,48 @@
+module Qmore
+  class Configuration
+    DYNAMIC_FALLBACK_KEY = "default".freeze
+
+    attr_accessor :dynamic_queues, :priority_buckets
+
+    def initialize
+      # Initialize the dynamic queues
+      self.dynamic_queues = {}
+      self.priority_buckets = []
+    end
+
+    def dynamic_queues=(hash)
+      queues = DynamicQueueHash.new
+      queues[DYNAMIC_FALLBACK_KEY] = ['*']
+      hash.each do |key, values|
+        queues[key] = values
+      end
+      @dynamic_queues = queues
+    end
+
+    # @param [Array] priorities
+    def priority_buckets=(priorities)
+      priorities << {'pattern' => 'default'} unless priorities.find {|b| b['pattern'] == 'default' }
+      @priority_buckets = priorities
+    end
+
+    private
+
+    class DynamicQueueHash < Hash
+      # @param key [String]
+      # @param values [Array]
+      def []=(key,values)
+        # remove any keys that have been set to empty hash or nil.
+        if values.nil? || values.size == 0
+          self.delete(key)
+          return
+        end
+
+        super
+      end
+
+      def [](key)
+        super(key) || super(DYNAMIC_FALLBACK_KEY)
+      end
+    end
+  end
+end

--- a/lib/qmore/configuration.rb
+++ b/lib/qmore/configuration.rb
@@ -45,4 +45,30 @@ module Qmore
       end
     end
   end
+
+  # Legacy style configuration which loads the configuration on each access.
+  class LegacyConfiguration
+    def initialize(persistence)
+      @configuration = Configuration.new
+      @persistence = persistence
+    end
+
+    def dynamic_queues=(hash)
+      @configuration.dynamic_queues = hash
+    end
+
+    def priority_buckets=(priorities)
+      @configuration.priority_buckets = priorities
+    end
+
+    def priority_buckets
+      @configuration.priority_buckets = @persistence.read_priority_buckets
+      @configuration.priority_buckets
+    end
+
+    def dynamic_queues
+      @configuration.dynamic_queues = @persistence.read_dynamic_queues
+      @configuration.dynamic_queues
+    end
+  end
 end

--- a/lib/qmore/job_reserver.rb
+++ b/lib/qmore/job_reserver.rb
@@ -49,7 +49,7 @@ module Qmore
       matched_names = expand_queues(regexes, queue_names)
 
       # Prioritize the queues.
-      prioritized_names = prioritize_queues(Qmore.configuration.priority_buckets,, matched_names)
+      prioritized_names = prioritize_queues(Qmore.configuration.priority_buckets, matched_names)
 
       # collect the matched queues names in prioritized order.
       prioritized_names.collect {|name| actual_queues[name] }

--- a/lib/qmore/job_reserver.rb
+++ b/lib/qmore/job_reserver.rb
@@ -51,7 +51,7 @@ module Qmore
         matched_names = expand_queues(regexes, queue_names)
 
         # Prioritize the queues.
-        prioritized_names = prioritize_queues(get_priority_buckets, matched_names)
+        prioritized_names = prioritize_queues(Qmore.configuration.priority_buckets, matched_names)
 
         # add the matched queues to the resulting list.
         realized_queues.concat(prioritized_names.collect {|name| actual_queues[name] })

--- a/lib/qmore/persistance.rb
+++ b/lib/qmore/persistance.rb
@@ -1,0 +1,101 @@
+module Qmore::Persistance
+  class Monitor
+    attr_reader :updating, :interval
+    # @param [Qmore::Persistance] persistance - responsible for reading the configuration
+    # from some source (redis, file, db, etc)
+    # @param [Integer] interval - the period, in seconds, to wait between updates to the configuration.
+    # defaults to 1 minute
+    def initialize(persistance, interval)
+      @persistance = persistance
+      @interval = interval
+    end
+
+    def start
+      return if @updating
+      @updating = true
+
+      # Ensure we load the configuration once from persistance before
+      # the background thread.
+      Qmore.configuration = @persistance.load
+
+      Thread.new do
+        while(@updating) do
+          sleep @interval
+          Qmore.configuration = @persistance.load
+        end
+      end
+    end
+
+    def stop
+      @updating = false
+    end
+  end
+
+  class Redis
+    DYNAMIC_QUEUE_KEY = "qmore:dynamic".freeze
+    PRIORITY_KEY = "qmore:priority".freeze
+
+    attr_reader :redis
+
+    def initialize(redis)
+      @redis = redis
+    end
+
+    def decode(data)
+      MultiJson.load(data) if data
+    end
+
+    def encode(data)
+      MultiJson.dump(data)
+    end
+
+    # Returns a Qmore::Configuration from the underlying data storage mechanism
+    # @return [Qmore::Configuration]
+    def load
+      configuration = Qmore::Configuration.new
+      configuration.dynamic_queues = self.read_dynamic_queues
+      configuration.priority_buckets = self.read_priority_buckets
+      configuration
+    end
+
+    # Writes out the configuration to the underlying data storage mechanism.
+    # @param[Qmore::Configuration] configuration to be persisted
+    def write(configuration)
+      write_dynamic_queues(configuration.dynamic_queues)
+      write_priority_buckets(configuration.priority_buckets)
+    end
+
+    protected
+
+    def read_dynamic_queues
+      result = {}
+      queues = redis.hgetall(DYNAMIC_QUEUE_KEY)
+      queues.each {|k, v| result[k] = decode(v) }
+      return result
+    end
+
+    def read_priority_buckets
+      priorities = Array(redis.lrange(PRIORITY_KEY, 0, -1))
+      priorities = priorities.collect {|p| decode(p) }
+      return priorities
+    end
+
+    def write_priority_buckets(data)
+      redis.multi do
+        redis.del(PRIORITY_KEY)
+        Array(data).each do |v|
+           redis.rpush(PRIORITY_KEY, encode(v))
+        end
+      end
+    end
+
+    def write_dynamic_queues(dynamic_queues)
+      redis.multi do
+        redis.del(DYNAMIC_QUEUE_KEY)
+        dynamic_queues.each do |k, v|
+          redis.hset(DYNAMIC_QUEUE_KEY, k, encode(v))
+        end
+      end
+    end
+  end
+end

--- a/lib/qmore/persistence.rb
+++ b/lib/qmore/persistence.rb
@@ -1,5 +1,7 @@
 module Qmore::Persistence
   class Monitor
+    include GemLogger::LoggerSupport
+
     attr_reader :updating, :interval
     # @param [Qmore::persistence] persistence - responsible for reading the configuration
     # from some source (redis, file, db, etc)
@@ -21,7 +23,11 @@ module Qmore::Persistence
       Thread.new do
         while(@updating) do
           sleep @interval
-          Qmore.configuration = @persistence.load
+          begin
+            Qmore.configuration = @persistence.load
+          rescue => e
+            logger.error "#{e.class.name} : #{e.message}"
+          end
         end
       end
     end

--- a/lib/qmore/persistence.rb
+++ b/lib/qmore/persistence.rb
@@ -1,12 +1,12 @@
-module Qmore::Persistance
+module Qmore::Persistence
   class Monitor
     attr_reader :updating, :interval
-    # @param [Qmore::Persistance] persistance - responsible for reading the configuration
+    # @param [Qmore::persistence] persistence - responsible for reading the configuration
     # from some source (redis, file, db, etc)
     # @param [Integer] interval - the period, in seconds, to wait between updates to the configuration.
     # defaults to 1 minute
-    def initialize(persistance, interval)
-      @persistance = persistance
+    def initialize(persistence, interval)
+      @persistence = persistence
       @interval = interval
     end
 
@@ -14,14 +14,14 @@ module Qmore::Persistance
       return if @updating
       @updating = true
 
-      # Ensure we load the configuration once from persistance before
+      # Ensure we load the configuration once from persistence before
       # the background thread.
-      Qmore.configuration = @persistance.load
+      Qmore.configuration = @persistence.load
 
       Thread.new do
         while(@updating) do
           sleep @interval
-          Qmore.configuration = @persistance.load
+          Qmore.configuration = @persistence.load
         end
       end
     end
@@ -64,8 +64,6 @@ module Qmore::Persistance
       write_dynamic_queues(configuration.dynamic_queues)
       write_priority_buckets(configuration.priority_buckets)
     end
-
-    protected
 
     def read_dynamic_queues
       result = {}

--- a/lib/qmore/server.rb
+++ b/lib/qmore/server.rb
@@ -8,7 +8,7 @@ module Qmore
     def self.registered(app)
 
       app.helpers do
-        
+
         def qmore_view(filename, options = {}, locals = {})
           options = {:layout => true, :locals => { :title => filename.to_s.capitalize }}.merge(options)
           dir = File.expand_path("../server/views/", __FILE__)
@@ -24,7 +24,7 @@ module Qmore
           queue_tab_index = original_tabs.index {|t| t[:name] == 'Queues' }
           original_tabs.insert(queue_tab_index + 1, *qmore_tabs)
         end
-        
+
       end
 
       #
@@ -34,7 +34,7 @@ module Qmore
       app.get "/dynamicqueues" do
         @queues = []
         real_queues = Qmore.client.queues.counts.collect {|q| q['name'] }
-        dqueues = Attr.get_dynamic_queues
+        dqueues = Qmore.configuration.dynamic_queues
         dqueues.each do |k, v|
           expanded = Attr.expand_queues(["@#{k}"], real_queues)
           expanded = expanded.collect { |q| q.split(":").last }
@@ -69,7 +69,10 @@ module Qmore
           values = queue['value'].to_s.split(',').collect { |q| q.gsub(/\s/, '') }
           queues[key] = values
         end
-        Attr.set_dynamic_queues(queues)
+
+        Qmore.configuration.dynamic_queues = queues
+        Qmore.persistance.write(Qmore.configuration)
+
         redirect to("/dynamicqueues")
       end
 
@@ -78,13 +81,16 @@ module Qmore
       #
 
       app.get "/queuepriority" do
-        @priorities = Attr.get_priority_buckets
+        @priorities = Qmore.configuration.priority_buckets
         qmore_view :priorities
       end
 
       app.post "/queuepriority" do
         priorities = params['priorities']
-        Attr.set_priority_buckets priorities
+
+        Qmore.configuration.priority_buckets = priorities
+        Qmore.persistance.write(Qmore.configuration)
+
         redirect to("/queuepriority")
       end
 

--- a/qmore.gemspec
+++ b/qmore.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency("qless", '~> 0.9')
   s.add_dependency("multi_json", '~> 1.7')
+  s.add_dependency("gem_logger")
 
   s.add_development_dependency('rake')
   s.add_development_dependency('rspec')

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,78 @@
+require "spec_helper"
+
+describe "Qmore::Configuration" do
+  before(:each) do
+    Qmore.client.redis.flushall
+  end
+
+  context "dynamic queues" do
+    it "should always have a fallback pattern" do
+      configuration = Qmore::Configuration.new
+
+      configuration.dynamic_queues['default'].should == ['*']
+    end
+
+    it "should default any unspecified keys to default pattern" do
+      configuration = Qmore::Configuration.new
+      configuration.dynamic_queues['foo'].should == ['*']
+
+      configuration.dynamic_queues[Qmore::Configuration::DYNAMIC_FALLBACK_KEY] = ["foo", "bar"]
+      configuration.dynamic_queues['foo'].should == ["foo", "bar"]
+    end
+
+    it "should allow setting single patterns" do
+      configuration = Qmore::Configuration.new
+
+      configuration.dynamic_queues['foo'].should == ['*']
+      configuration.dynamic_queues['foo'] = ['bar']
+      configuration.dynamic_queues['foo'].should == ['bar']
+    end
+
+    it "should allow changing the pattern of the fallback key" do
+      configuration = Qmore::Configuration.new
+      configuration.dynamic_queues[Qmore::Configuration::DYNAMIC_FALLBACK_KEY].should == ['*']
+      configuration.dynamic_queues[Qmore::Configuration::DYNAMIC_FALLBACK_KEY] = ['foo', 'bar']
+      configuration.dynamic_queues[Qmore::Configuration::DYNAMIC_FALLBACK_KEY].should == ['foo', 'bar']
+    end
+
+    it "should ignore mappings when setting empty value" do
+      configuration = Qmore::Configuration.new
+      configuration.dynamic_queues = {'foo' => ['bar'], 'baz' => ['boo']}
+      configuration.dynamic_queues.should == {'default' => ['*'], 'foo' => ['bar'], 'baz' => ['boo']}
+
+      configuration.dynamic_queues = {'foo' => [], 'baz' => ['boo']}
+      configuration.dynamic_queues.should == {'default' => ['*'], 'baz' => ['boo']}
+      configuration.dynamic_queues = {'baz' => nil}
+      configuration.dynamic_queues.should == {'default' => ['*']}
+
+      configuration.dynamic_queues = {'foo' => ['bar'], 'baz' => ['boo']}
+      configuration.dynamic_queues['foo'] = []
+      configuration.dynamic_queues.should == {'default' => ["*"], 'baz' => ['boo']}
+      configuration.dynamic_queues['baz'] = nil
+      configuration.dynamic_queues.should == {'default' => ['*']}
+    end
+  end
+
+  context "priority attributes" do
+    it "should have a default priority" do
+      configuration = Qmore::Configuration.new
+      configuration.priority_buckets.should == [{'pattern' => 'default'}]
+    end
+
+    it "can set priorities" do
+      expected_priority_buckets = [{'pattern' => 'foo', 'fairly' => 'false'},{'pattern' => 'default'}]
+      configuration = Qmore::Configuration.new
+      configuration.priority_buckets = [{'pattern' => 'foo', 'fairly' => 'false'}]
+      configuration.priority_buckets.should == expected_priority_buckets
+    end
+
+    it "can set priorities including default" do
+      expected_priority_buckets = [{'pattern' => 'foo', 'fairly' => false},
+                                   {'pattern' => 'default', 'fairly' => false},
+                                   {'pattern' => 'bar', 'fairly' => true}]
+      configuration = Qmore::Configuration.new
+      configuration.priority_buckets = expected_priority_buckets
+      configuration.priority_buckets.should == expected_priority_buckets
+    end
+  end
+end

--- a/spec/job_reserver_spec.rb
+++ b/spec/job_reserver_spec.rb
@@ -5,6 +5,7 @@ describe "JobReserver" do
 
   before(:each) do
     Qmore.client.redis.flushall
+    Qmore.configuration = Qmore::Configuration.new
   end
 
   context "multiple qless server environment" do
@@ -91,7 +92,7 @@ describe "JobReserver" do
     end
 
     it "handles priorities" do
-      set_priority_buckets [{'pattern' => 'foo*', 'fairly' => false},
+      Qmore.configuration.priority_buckets = [{'pattern' => 'foo*', 'fairly' => false},
                             {'pattern' => 'default', 'fairly' => false},
                             {'pattern' => 'bar', 'fairly' => true}]
 

--- a/spec/persistance_spec.rb
+++ b/spec/persistance_spec.rb
@@ -1,21 +1,21 @@
 require "spec_helper"
 
-describe "Qmore::Persistance::Monitor" do
+describe "Qmore::Persistence::Monitor" do
   before(:each) do
     Qmore.client.redis.flushall
   end
 
   it "updates periodically based on the interval" do
-    persistance = double("Qmore::Persistance::Redis")
+    persistance = double("Qmore::Persistence::Redis")
     persistance.should_receive(:load).at_least(3)
-    monitor = Qmore::Persistance::Monitor.new(persistance, 1)
+    monitor = Qmore::Persistence::Monitor.new(persistance, 1)
     monitor.start
     sleep 4
     monitor.stop
   end
 end
 
-describe "Qmore::Persistance::Redis" do
+describe "Qmore::Persistence::Redis" do
   before(:each) do
     Qmore.client.redis.flushall
   end
@@ -31,7 +31,7 @@ describe "Qmore::Persistance::Redis" do
 
       configuration = Qmore::Configuration.new
       configuration.dynamic_queues = queues
-      persistance = Qmore::Persistance::Redis.new(Qmore.client.redis)
+      persistance = Qmore::Persistence::Redis.new(Qmore.client.redis)
       persistance.write(configuration)
 
       actual_configuration = persistance.load
@@ -46,7 +46,7 @@ describe "Qmore::Persistance::Redis" do
       configuration = Qmore::Configuration.new
       configuration.priority_buckets = priorities
 
-      persistance = Qmore::Persistance::Redis.new(Qmore.client.redis)
+      persistance = Qmore::Persistence::Redis.new(Qmore.client.redis)
       persistance.write(configuration)
 
       actual_configuration = persistance.load

--- a/spec/persistance_spec.rb
+++ b/spec/persistance_spec.rb
@@ -1,0 +1,57 @@
+require "spec_helper"
+
+describe "Qmore::Persistance::Monitor" do
+  before(:each) do
+    Qmore.client.redis.flushall
+  end
+
+  it "updates periodically based on the interval" do
+    persistance = double("Qmore::Persistance::Redis")
+    persistance.should_receive(:load).at_least(3)
+    monitor = Qmore::Persistance::Monitor.new(persistance, 1)
+    monitor.start
+    sleep 4
+    monitor.stop
+  end
+end
+
+describe "Qmore::Persistance::Redis" do
+  before(:each) do
+    Qmore.client.redis.flushall
+  end
+
+
+  context "dynamic queues" do
+    it "can read/write dynamic queues to redis" do
+      queues = {
+        "key_a" => ["foo"],
+        "key_b" => ["bar"],
+        "key_c" => ["foo", "bar"]
+      }
+
+      configuration = Qmore::Configuration.new
+      configuration.dynamic_queues = queues
+      persistance = Qmore::Persistance::Redis.new(Qmore.client.redis)
+      persistance.write(configuration)
+
+      actual_configuration = persistance.load
+
+      configuration.dynamic_queues.should == actual_configuration.dynamic_queues
+    end
+  end
+
+  context "priorities" do
+    it "can read/write priorities to redis" do
+      priorities = [{'pattern' => 'foo*', 'fairly' => false},{'pattern' => 'default', 'fairly' => false}]
+      configuration = Qmore::Configuration.new
+      configuration.priority_buckets = priorities
+
+      persistance = Qmore::Persistance::Redis.new(Qmore.client.redis)
+      persistance.write(configuration)
+
+      actual_configuration = persistance.load
+      configuration.priority_buckets.should == actual_configuration.priority_buckets
+    end
+  end
+end
+

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -49,6 +49,7 @@ describe "Qmore Server" do
       it "should shows names of queues" do
         Qmore.configuration.dynamic_queues["key_one"] = ["foo"]
         Qmore.configuration.dynamic_queues["key_two"] = ["bar"]
+        Qmore.persistence.write(Qmore.configuration)
 
         get "/dynamicqueues"
 
@@ -59,6 +60,7 @@ describe "Qmore Server" do
       it "should shows values of queues" do
         Qmore.configuration.dynamic_queues["key_one"] = ["foo"]
         Qmore.configuration.dynamic_queues["key_two"] = ["bar", "baz"]
+        Qmore.persistence.write(Qmore.configuration)
 
         get "/dynamicqueues"
 
@@ -72,6 +74,7 @@ describe "Qmore Server" do
 
       it "should show remove link for queue" do
         Qmore.configuration.dynamic_queues["key_one"] = ["foo"]
+        Qmore.persistence.write(Qmore.configuration)
 
         get "/dynamicqueues"
 
@@ -97,6 +100,8 @@ describe "Qmore Server" do
       it "should show input fields" do
         Qmore.configuration.dynamic_queues["key_one"] = ["foo"]
         Qmore.configuration.dynamic_queues["key_two"] = ["bar", "baz"]
+        Qmore.persistence.write(Qmore.configuration)
+
         get "/dynamicqueues"
 
         last_response.body.should match /<input type="text" id="input-0-name" name="queues\[\]\[name\]" value="key_one"/
@@ -107,6 +112,9 @@ describe "Qmore Server" do
 
       it "should delete queues on empty queue submit" do
         Qmore.configuration.dynamic_queues["key_two"] = ["bar", "baz"]
+        Qmore.persistence.write(Qmore.configuration)
+        Qmore.persistence.load.dynamic_queues.has_key?("key_two").should == true
+
         post "/dynamicqueues", {'queues' => [{'name' => "key_two", "value" => ""}]}
 
         last_response.should be_redirect
@@ -124,6 +132,8 @@ describe "Qmore Server" do
 
       it "should update queues" do
         Qmore.configuration.dynamic_queues["key_two"] = ["bar", "baz"]
+        Qmore.persistence.write(Qmore.configuration)
+
         post "/dynamicqueues", {'queues' => [{'name' => "key_two", "value" => "foo,bar,baz"}]}
 
         last_response.should be_redirect
@@ -157,6 +167,7 @@ describe "Qmore Server" do
         Qmore.configuration.priority_buckets = [{'pattern' => 'foo', 'fairly' => false},
                                                 {'pattern' => 'default', 'fairly' => false},
                                                 {'pattern' => 'bar', 'fairly' => true}]
+        Qmore.persistence.write(Qmore.configuration)
       end
 
       it "should shows pattern input fields" do
@@ -183,6 +194,7 @@ describe "Qmore Server" do
         Qmore.configuration.priority_buckets = [{'pattern' => 'foo', 'fairly' => false},
                                                 {'pattern' => 'default', 'fairly' => false},
                                                 {'pattern' => 'bar', 'fairly' => true}]
+        Qmore.persistence.write(Qmore.configuration)
       end
 
       it "should show remove link for queue" do

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -9,7 +9,7 @@ require 'orderedhash'
 Sinatra::Base.set :environment, :test
 
 describe "Qmore Server" do
-  
+
   include Rack::Test::Methods
   include Qmore::Attributes
 
@@ -19,219 +19,218 @@ describe "Qmore Server" do
 
   before(:each) do
     Qmore.client.redis.flushall
+    Qmore.configuration = Qmore::Configuration.new
   end
 
   context "DynamicQueue" do
-    
+
     context "existence in application" do
-  
+
       it "should respond to it's url" do
         get "/dynamicqueues"
         last_response.should be_ok
       end
-  
+
       it "should display its tab" do
         get "/queues"
         last_response.body.should include "<a href='/dynamicqueues'>DynamicQueues</a>"
       end
-  
+
     end
-  
+
     context "show dynamic queues table" do
-  
+
       it "should shows default queue when nothing set" do
         get "/dynamicqueues"
-  
+
         last_response.body.should include 'default'
       end
-  
+
       it "should shows names of queues" do
-        set_dynamic_queue("key_one", ["foo"])
-        set_dynamic_queue("key_two", ["bar"])
-  
+        Qmore.configuration.dynamic_queues["key_one"] = ["foo"]
+        Qmore.configuration.dynamic_queues["key_two"] = ["bar"]
+
         get "/dynamicqueues"
-  
+
         last_response.body.should include 'key_one'
         last_response.body.should include 'key_two'
       end
-  
+
       it "should shows values of queues" do
-        set_dynamic_queue("key_one", ["foo"])
-        set_dynamic_queue("key_two", ["bar", "baz"])
-  
+        Qmore.configuration.dynamic_queues["key_one"] = ["foo"]
+        Qmore.configuration.dynamic_queues["key_two"] = ["bar", "baz"]
+
         get "/dynamicqueues"
-  
+
         last_response.body.should include 'foo'
         last_response.body.should include 'bar, baz'
       end
-  
+
     end
-  
+
     context "remove queue link" do
-  
+
       it "should show remove link for queue" do
-        set_dynamic_queue("key_one", ["foo"])
-  
+        Qmore.configuration.dynamic_queues["key_one"] = ["foo"]
+
         get "/dynamicqueues"
-  
+
         last_response.body.should match /<a .*href=['"]#remove['"].*>/
       end
-  
+
       it "should show add link" do
         get "/dynamicqueues"
-  
+
         last_response.body.should match /<a .*href=['"]#add['"].*>/
       end
-  
+
     end
-  
+
     context "form to edit queues" do
-  
+
       it "should have form to edit queues" do
         get "/dynamicqueues"
-  
+
         last_response.body.should match /<form action="\/dynamicqueues"/
       end
-      
+
       it "should show input fields" do
-        set_dynamic_queue("key_one", ["foo"])
-        set_dynamic_queue("key_two", ["bar", "baz"])
+        Qmore.configuration.dynamic_queues["key_one"] = ["foo"]
+        Qmore.configuration.dynamic_queues["key_two"] = ["bar", "baz"]
         get "/dynamicqueues"
-  
+
         last_response.body.should match /<input type="text" id="input-0-name" name="queues\[\]\[name\]" value="key_one"/
         last_response.body.should match /<input type="text" id="input-0-value" name="queues\[\]\[value\]" value="foo"/
         last_response.body.should match /<input type="text" id="input-1-name" name="queues\[\]\[name\]" value="key_two"/
         last_response.body.should match /<input type="text" id="input-1-value" name="queues\[\]\[value\]" value="bar, baz"/
       end
-  
+
       it "should delete queues on empty queue submit" do
-        set_dynamic_queue("key_two", ["bar", "baz"])
+        Qmore.configuration.dynamic_queues["key_two"] = ["bar", "baz"]
         post "/dynamicqueues", {'queues' => [{'name' => "key_two", "value" => ""}]}
-  
+
         last_response.should be_redirect
         last_response['Location'].should match /dynamicqueues/
-        get_dynamic_queue("key_two", []).should be_empty
+        Qmore.configuration.dynamic_queues.has_key?("key_two").should == false
       end
-  
+
       it "should create queues" do
         post "/dynamicqueues", {'queues' => [{'name' => "key_two", "value" => " foo, bar ,baz "}]}
-  
+
         last_response.should be_redirect
         last_response['Location'].should match /dynamicqueues/
-        get_dynamic_queue("key_two").should == %w{foo bar baz}
+        Qmore.configuration.dynamic_queues["key_two"].should == %w{foo bar baz}
       end
-  
+
       it "should update queues" do
-        set_dynamic_queue("key_two", ["bar", "baz"])
+        Qmore.configuration.dynamic_queues["key_two"] = ["bar", "baz"]
         post "/dynamicqueues", {'queues' => [{'name' => "key_two", "value" => "foo,bar,baz"}]}
-  
+
         last_response.should be_redirect
         last_response['Location'].should match /dynamicqueues/
-        get_dynamic_queue("key_two").should == %w{foo bar baz}
+        Qmore.configuration.dynamic_queues["key_two"].should == %w{foo bar baz}
       end
-  
+
     end
 
   end
-  
+
   context "QueuePriority" do
 
     context "existence in application" do
-  
+
       it "should respond to it's url" do
         get "/queuepriority"
         last_response.should be_ok
       end
-  
+
       it "should display its tab" do
         get "/queues"
         last_response.body.should include "<a href='/queuepriority'>QueuePriority</a>"
       end
-  
+
     end
-  
+
     context "show queue priority table" do
-  
+
       before(:each) do
-        set_priority_buckets [{'pattern' => 'foo', 'fairly' => false},
-                                   {'pattern' => 'default', 'fairly' => false},
-                                   {'pattern' => 'bar', 'fairly' => true}]
-  
+        Qmore.configuration.priority_buckets = [{'pattern' => 'foo', 'fairly' => false},
+                                                {'pattern' => 'default', 'fairly' => false},
+                                                {'pattern' => 'bar', 'fairly' => true}]
       end
-  
+
       it "should shows pattern input fields" do
         get "/queuepriority"
-  
+
         last_response.body.should match /<input type="text" id="input-0-pattern" name="priorities\[\]\[pattern\]" value="foo"/
         last_response.body.should match /<input type="text" id="input-1-pattern" name="priorities\[\]\[pattern\]" value="default"/
         last_response.body.should match /<input type="text" id="input-2-pattern" name="priorities\[\]\[pattern\]" value="bar"/
       end
-  
+
       it "should show fairly checkboxes" do
         get "/queuepriority"
-  
+
         last_response.body.should match /<input type="checkbox" id="input-0-fairly" name="priorities\[\]\[fairly\]" value="true" *\/>/
         last_response.body.should match /<input type="checkbox" id="input-1-fairly" name="priorities\[\]\[fairly\]" value="true" *\/>/
         last_response.body.should match /<input type="checkbox" id="input-2-fairly" name="priorities\[\]\[fairly\]" value="true" checked *\/>/
       end
-  
+
     end
-  
+
     context "edit links" do
-  
+
       before(:each) do
-        set_priority_buckets [{'pattern' => 'foo', 'fairly' => false},
-                                   {'pattern' => 'default', 'fairly' => false},
-                                   {'pattern' => 'bar', 'fairly' => true}]
-  
+        Qmore.configuration.priority_buckets = [{'pattern' => 'foo', 'fairly' => false},
+                                                {'pattern' => 'default', 'fairly' => false},
+                                                {'pattern' => 'bar', 'fairly' => true}]
       end
-  
+
       it "should show remove link for queue" do
         get "/queuepriority"
-  
+
         last_response.body.should match /<a href="#remove"/
       end
-  
+
       it "should show up link for queue" do
         get "/queuepriority"
-  
+
         last_response.body.should match /<a href="#up"/
       end
-  
+
       it "should show down link for queue" do
         get "/queuepriority"
-  
+
         last_response.body.should match /<a href="#down"/
       end
-  
+
     end
-  
+
     context "form to edit queues" do
-  
+
       it "should have form to edit queues" do
         get "/queuepriority"
-  
+
         last_response.body.should match /<form action="\/queuepriority"/
       end
-  
+
       it "should update queues" do
-        get_priority_buckets.should == [{'pattern' => 'default'}]
-  
+        Qmore.configuration.priority_buckets.should == [{'pattern' => 'default'}]
+
         params = {'priorities' => [
             OrderedHash["pattern", "foo"],
             OrderedHash["pattern", "default"],
             OrderedHash["pattern", "bar", "fairly", "true"]
         ]}
-        post "/queuepriority", params 
-  
+        post "/queuepriority", params
+
         last_response.should be_redirect
         last_response['Location'].should match /queuepriority/
-        get_priority_buckets.should == [{"pattern" => "foo"},
+        Qmore.configuration.priority_buckets.should == [{"pattern" => "foo"},
                                            {"pattern" => "default"},
                                            {"pattern" => "bar", "fairly" => "true"}]
       end
-  
+
     end
-    
+
   end
 end


### PR DESCRIPTION
Prevents updating configuration every call to reserve a job by offloading the update into a background thread.
Still testing.
