### PR TITLE
Filter Strategy Bug Fix

### DIFF
--- a/lib/qmore/reservers/strategies/filtering.rb
+++ b/lib/qmore/reservers/strategies/filtering.rb
@@ -20,7 +20,10 @@ module Qmore::Reservers::Strategies
         prioritized_names = Filtering.prioritize_queues(Qmore.configuration.priority_buckets, matches)
 
         prioritized_names.each do |name|
-          yielder << mapped_queues[name]
+          queue = mapped_queues[name]
+          if queue
+            yielder << queue
+          end
         end
       end
     end

--- a/lib/qmore/reservers/strategies/sources.rb
+++ b/lib/qmore/reservers/strategies/sources.rb
@@ -4,9 +4,8 @@ module Qmore::Reservers::Strategies::Sources
   # pull work from. Ignores any queues that do not have tasks available.
   def self.direct(client)
     Enumerator.new do |yielder|
-      queues = client.queues.counts.reject do |queue|
-        total = %w(waiting recurring depends stalled scheduled).inject(0) { |sum, state| sum += queue[state].to_i }
-        total == 0
+      queues = client.queues.counts.select do |queue|
+        %w(waiting recurring depends stalled scheduled).any? {|state| queue[state].to_i > 0 }
       end
 
       queues.each do |queue|

--- a/spec/attributes_spec.rb
+++ b/spec/attributes_spec.rb
@@ -12,117 +12,117 @@ describe "Attributes" do
 
   context "basic queue patterns" do
     it "can specify simple queues" do
-      expand_queues(["foo"], @real_queues).should == ["foo"]
-      expand_queues(["foo", "bar"], @real_queues).should == ["bar", "foo"]
+      expect(expand_queues(["foo"], @real_queues)).to(eq(["foo"]))
+      expect(expand_queues(["foo", "bar"], @real_queues)).to(eq(["bar", "foo"]))
     end
 
     it "can specify simple wildcard" do
       worker = Qless::Worker.new("*")
-      expand_queues(["*"], @real_queues).should == ["foo", "high_x", "high_y", "superhigh_z"]
+      expect(expand_queues(["*"], @real_queues)).to(eq(["foo", "high_x", "high_y", "superhigh_z"]))
     end
 
     it "can include queues with pattern" do
-      expand_queues(["high*"], @real_queues).should == ["high_x", "high_y"]
-      expand_queues(["*high_z"], @real_queues).should == ["superhigh_z"]
-      expand_queues(["*high*"], @real_queues).should == ["high_x", "high_y", "superhigh_z"]
+      expect(expand_queues(["high*"], @real_queues)).to(eq(["high_x", "high_y"]))
+      expect(expand_queues(["*high_z"], @real_queues)).to(eq(["superhigh_z"]))
+      expect(expand_queues(["*high*"], @real_queues)).to(eq(["high_x", "high_y", "superhigh_z"]))
     end
 
     it "can blacklist queues" do
-      expand_queues(["*", "!foo"], @real_queues).should == ["high_x", "high_y", "superhigh_z"]
+      expect(expand_queues(["*", "!foo"], @real_queues)).to(eq(["high_x", "high_y", "superhigh_z"]))
     end
 
     it "can blacklist queues with pattern" do
-      expand_queues(["*", "!*high*"], @real_queues).should == ["foo"]
+      expect(expand_queues(["*", "!*high*"], @real_queues)).to(eq(["foo"]))
     end
   end
 
   context "expanding queues" do
     it "can dynamically lookup queues" do
       Qmore.configuration.dynamic_queues = {"mykey" => ["foo", "bar"]}
-      expand_queues(["@mykey"], @real_queues).should == ["bar", "foo"]
+      expect(expand_queues(["@mykey"], @real_queues)).to(eq(["bar", "foo"]))
     end
 
     it "can blacklist dynamic queues" do
       Qmore.configuration.dynamic_queues["mykey"] = ["foo"]
-      expand_queues(["*", "!@mykey"], @real_queues).should == ["high_x", "high_y", "superhigh_z"]
+      expect(expand_queues(["*", "!@mykey"], @real_queues)).to(eq(["high_x", "high_y", "superhigh_z"]))
     end
 
     it "can blacklist dynamic queues with negation" do
       Qmore.configuration.dynamic_queues["mykey"] = ["!foo", "high_x"]
-      expand_queues(["!@mykey"], @real_queues).should == ["foo"]
+      expect(expand_queues(["!@mykey"], @real_queues)).to(eq(["foo"]))
     end
 
     it "will not bloat the given real_queues" do
       orig = @real_queues.dup
       expand_queues(["@mykey"], @real_queues)
-      @real_queues.should == orig
+      expect(@real_queues).to(eq(orig))
     end
 
     it "uses hostname as default key in dynamic queues" do
       host = Socket.gethostname
       Qmore.configuration.dynamic_queues[host] = ["foo", "bar"]
 
-      expand_queues(["@"], @real_queues).should == ["bar", "foo"]
+      expect(expand_queues(["@"], @real_queues)).to(eq(["bar", "foo"]))
     end
 
     it "can use wildcards in dynamic queues" do
       Qmore.configuration.dynamic_queues["mykey"] = ["*high*", "!high_y"]
-      expand_queues(["@mykey"], @real_queues).should == ["high_x", "superhigh_z"]
+      expect(expand_queues(["@mykey"], @real_queues)).to(eq(["high_x", "superhigh_z"]))
     end
 
     it "falls back to default queues when missing" do
       Qmore.configuration.dynamic_queues["default"] = ["foo", "bar"]
-      expand_queues(["@mykey"], @real_queues).should == ["bar", "foo"]
+      expect(expand_queues(["@mykey"], @real_queues)).to(eq(["bar", "foo"]))
     end
 
     it "falls back to all queues when missing and no default" do
-      expand_queues(["@mykey"], @real_queues).should == ["foo", "high_x", "high_y", "superhigh_z"]
+      expect(expand_queues(["@mykey"], @real_queues)).to(eq(["foo", "high_x", "high_y", "superhigh_z"]))
     end
 
     it "falls back to all queues when missing and no default and keep up to date" do
-      expand_queues(["@mykey"], @real_queues).should == ["foo", "high_x", "high_y", "superhigh_z"]
+      expect(expand_queues(["@mykey"], @real_queues)).to(eq(["foo", "high_x", "high_y", "superhigh_z"]))
       @real_queues << "bar"
-      expand_queues(["@mykey"], @real_queues).should == ["bar", "foo", "high_x", "high_y", "superhigh_z"]
+      expect(expand_queues(["@mykey"], @real_queues)).to(eq(["bar", "foo", "high_x", "high_y", "superhigh_z"]))
     end
   end
 
   context "queue priorities" do
     it "should pick up all queues with default priority" do
       priority_buckets = [{'pattern' => 'default', 'fairly' => false}]
-      prioritize_queues(priority_buckets, @real_queues).should == ["high_x", "foo", "high_y", "superhigh_z"]
+      expect(prioritize_queues(priority_buckets, @real_queues)).to(eq(["high_x", "foo", "high_y", "superhigh_z"]))
     end
 
     it "should pick up all queues fairly" do
       # do a bunch to reduce likelyhood of random match causing test failure
       @real_queues = 50.times.collect { |i| "auto_#{i}" }
       priority_buckets = [{'pattern' => 'default', 'fairly' => true}]
-      prioritize_queues(priority_buckets, @real_queues).should_not == @real_queues.sort
-      prioritize_queues(priority_buckets, @real_queues).sort.should == @real_queues.sort
+      expect(prioritize_queues(priority_buckets, @real_queues)).not_to(eq(@real_queues.sort))
+      expect(prioritize_queues(priority_buckets, @real_queues).sort).to(eq(@real_queues.sort))
     end
 
     it "should prioritize simple pattern" do
       priority_buckets = [{'pattern' => 'superhigh_z', 'fairly' => false},
                           {'pattern' => 'default', 'fairly' => false}]
-      prioritize_queues(priority_buckets, @real_queues).should == ["superhigh_z", "high_x", "foo", "high_y"]
+      expect(prioritize_queues(priority_buckets, @real_queues)).to(eq(["superhigh_z", "high_x", "foo", "high_y"]))
     end
 
     it "should prioritize multiple simple patterns" do
       priority_buckets = [{'pattern' => 'superhigh_z', 'fairly' => false},
                           {'pattern' => 'default', 'fairly' => false},
                           {'pattern' => 'foo', 'fairly' => false}]
-      prioritize_queues(priority_buckets, @real_queues).should == ["superhigh_z", "high_x", "high_y", "foo"]
+      expect(prioritize_queues(priority_buckets, @real_queues)).to(eq(["superhigh_z", "high_x", "high_y", "foo"]))
     end
 
     it "should prioritize simple wildcard pattern" do
       priority_buckets = [{'pattern' => 'high*', 'fairly' => false},
                           {'pattern' => 'default', 'fairly' => false}]
-      prioritize_queues(priority_buckets, @real_queues).should == ["high_x", "high_y", "foo", "superhigh_z"]
+      expect(prioritize_queues(priority_buckets, @real_queues)).to(eq(["high_x", "high_y", "foo", "superhigh_z"]))
     end
 
     it "should prioritize simple wildcard pattern with correct matching" do
       priority_buckets = [{'pattern' => '*high*', 'fairly' => false},
                           {'pattern' => 'default', 'fairly' => false}]
-      prioritize_queues(priority_buckets, @real_queues).should == ["high_x", "high_y", "superhigh_z", "foo"]
+      expect(prioritize_queues(priority_buckets, @real_queues)).to(eq(["high_x", "high_y", "superhigh_z", "foo"]))
     end
 
     it "should prioritize negation patterns" do
@@ -130,31 +130,31 @@ describe "Attributes" do
       @real_queues << "high_x"
       priority_buckets = [{'pattern' => 'high*,!high_x', 'fairly' => false},
                           {'pattern' => 'default', 'fairly' => false}]
-      prioritize_queues(priority_buckets, @real_queues).should == ["high_y", "foo", "superhigh_z", "high_x"]
+      expect(prioritize_queues(priority_buckets, @real_queues)).to(eq(["high_y", "foo", "superhigh_z", "high_x"]))
     end
 
     it "should not be affected by standalone negation patterns" do
       priority_buckets = [{'pattern' => '!high_x', 'fairly' => false},
                           {'pattern' => 'default', 'fairly' => false}]
-      prioritize_queues(priority_buckets, @real_queues).should == ["high_x", "foo", "high_y", "superhigh_z"]
+      expect(prioritize_queues(priority_buckets, @real_queues)).to(eq(["high_x", "foo", "high_y", "superhigh_z"]))
     end
 
     it "should allow multiple inclusive patterns" do
       priority_buckets = [{'pattern' => 'high_x, superhigh*', 'fairly' => false},
                           {'pattern' => 'default', 'fairly' => false}]
-      prioritize_queues(priority_buckets, @real_queues).should == ["high_x", "superhigh_z", "foo", "high_y"]
+      expect(prioritize_queues(priority_buckets, @real_queues)).to(eq(["high_x", "superhigh_z", "foo", "high_y"]))
     end
 
     it "should prioritize fully inclusive wildcard pattern" do
       priority_buckets = [{'pattern' => '*high*', 'fairly' => false},
                           {'pattern' => 'default', 'fairly' => false}]
-      prioritize_queues(priority_buckets, @real_queues).should == ["high_x", "high_y", "superhigh_z", "foo"]
+      expect(prioritize_queues(priority_buckets, @real_queues)).to(eq(["high_x", "high_y", "superhigh_z", "foo"]))
     end
 
     it "should handle empty default match" do
       priority_buckets = [{'pattern' => '*', 'fairly' => false},
                           {'pattern' => 'default', 'fairly' => false}]
-      prioritize_queues(priority_buckets, @real_queues).should == ["high_x", "foo", "high_y", "superhigh_z"]
+      expect(prioritize_queues(priority_buckets, @real_queues)).to(eq(["high_x", "foo", "high_y", "superhigh_z"]))
     end
 
     it "should pickup wildcard queues fairly" do
@@ -164,8 +164,10 @@ describe "Attributes" do
       priority_buckets = [{'pattern' => 'other*', 'fairly' => true},
                           {'pattern' => 'default', 'fairly' => false}]
       queues = prioritize_queues(priority_buckets, @real_queues)
-      (queues[0..4].sort).to eq(others.sort)
-      queues[5..-1].to eq(["high_x", "foo", "high_y", "superhigh_z"])
+
+      expect(queues[0..4].sort).to eq(others.sort)
+
+      expect(queues[5..-1]).to eq(["high_x", "foo", "high_y", "superhigh_z"])
       expect(queues).not_to eq(others.sort + ["high_x", "foo", "high_y", "superhigh_z"])
     end
   end

--- a/spec/reservers/strategies/filtering_spec.rb
+++ b/spec/reservers/strategies/filtering_spec.rb
@@ -42,8 +42,7 @@ describe "Reservers::Strategies::Filtering" do
                             {'pattern' => 'default', 'fairly' => false},
                             {'pattern' => 'bar', 'fairly' => true}]
 
-      queues = []
-      ['other', 'blah', 'foobie', 'bar', 'foo'].each do |q|
+      queues = ['other', 'blah', 'foobie', 'bar', 'foo'].reduce([]) do |queues, q|
         queue = Qmore.client.queues[q]
         queue.put(SomeJob, {})
         expect(queue.length).to be(1)
@@ -57,6 +56,13 @@ describe "Reservers::Strategies::Filtering" do
       expect(filter.next.name).to eq('other')
       expect(filter.next.name).to eq('bar')
       expect { filter.next }.to raise_error(StopIteration)
+    end
+
+    it "should return an empty array if nothing matches the filter" do
+      queue = Qmore.client.queues["filtered"]
+
+      filter = Qmore::Reservers::Strategies::Filtering.default([queue], ['queue'])
+      expect(filter.to_a).to(eq([]))
     end
   end
 end


### PR DESCRIPTION
Fixes a bug where filter strategy would return nil for if no queues were found.

updated attributes_spec to remove deprecation warnings.

simplified the direct queue source strategy logic for easier understanding.
