### PR TITLE
Reset negate state when expanding queue names

### DIFF
--- a/lib/qmore/attributes.rb
+++ b/lib/qmore/attributes.rb
@@ -25,6 +25,7 @@ module Qmore
 
       while q = queue_patterns.shift
         q = q.to_s
+        negated = false
 
         if q =~ /^(!)?@(.*)/
           key = $2.strip

--- a/spec/attributes_spec.rb
+++ b/spec/attributes_spec.rb
@@ -52,6 +52,10 @@ describe "Attributes" do
       expand_queues(["!@mykey"], @real_queues).should == ["foo"]
     end
 
+    it "continues matching patterns following a blacklisted pattern" do
+      expand_queues(["!f*", "!*high*", "*foo*"], @real_queues).should == ["foo"]
+    end
+
     it "will not bloat the given real_queues" do
       orig = @real_queues.dup
       expand_queues(["@mykey"], @real_queues)


### PR DESCRIPTION
Because `while` doesn't create a new scope, `negated` needs to be explicitly reset to `false` each iteration of the queue expansion loop. Without resetting `negated`, all patterns following a negated pattern are treated as negating patterns.

Hope you're well :smile: 
